### PR TITLE
增加腾讯云解析线路支持

### DIFF
--- a/src/components/DomainRecords.vue
+++ b/src/components/DomainRecords.vue
@@ -353,6 +353,20 @@ const baseColumns = [
         align: "center",
         width: 76,
     },
+    {
+        title: "线路类型",
+        dataIndex: "RecordLine",
+        key: "RecordLine",
+        align: "center",
+        width: 120,
+        customRender: ({record}) => {
+            // 只有腾讯云才显示线路信息
+            if (nowDomainInfo.value.cloud === 'tencent') {
+                return record.RecordLine || '默认';
+            }
+            return '-';
+        }
+    },
 ];
 
 const actionColumn = {

--- a/src/service/DnsService.js
+++ b/src/service/DnsService.js
@@ -219,4 +219,38 @@ class DnsService {
             return this.provider.changeRecordStatus(domain, recordId, extra);
         }
     }
+
+    // 获取线路列表（仅腾讯云支持）
+    async getRecordLineList(domain) {
+        if (typeof this.provider.getRecordLineList === 'function') {
+            return this.provider.getRecordLineList(domain);
+        }
+        // 其他云服务商返回默认线路
+        return {
+            count: 1,
+            list: [{
+                name: '默认',
+                id: '0',
+                category: '基础线路'
+            }]
+        };
+    }
+
+    // 按分类获取线路列表（仅腾讯云支持）
+    async getRecordLineCategoryList(domain) {
+        if (typeof this.provider.getRecordLineCategoryList === 'function') {
+            return this.provider.getRecordLineCategoryList(domain);
+        }
+        // 其他云服务商返回默认线路
+        return {
+            count: 1,
+            list: [{
+                name: '默认',
+                id: '0',
+                useful: true,
+                grade: 'DP_Free',
+                subLines: []
+            }]
+        };
+    }
 }


### PR DESCRIPTION
支持腾讯云显示"线路类型', "选择线路". 

目前还有bug: 

1. 未获取用户的DNS套餐等级, 只能按免费版的线路分类进行选择;
2. 线路类型 的选择没有腾讯云上直观, 目前就一个列表拉到底.

--- 

不过基本可用. 